### PR TITLE
Create flag to initialize fikkie

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ expected, and fikkie will let you know when something's wrong.
 
 ## Installation
 
-Install fikkie using pip:
+Install fikkie using pip and initialize fikkie:
 
 ```bash
 pip install fikkie
+fikkie --init
 ```
 
 ## Config example

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Installing fikkie is easy!
 
 ```bash
 pip install fikkie
+fikkie --init
 ```
 
 
@@ -63,7 +64,7 @@ fikkie ALL=(ALL) NOPASSWD: /path/to/command1, /path/to/command2
 
 ### Setting up fikkie
 
-The first time you run `fikkie`, a configuration template is placed in
+When you run `fikkie --init`, a configuration template is placed in
 `~/.fikkie/config.yaml`. Edit this file to specify the servers you want to
 monitor and which notifiers should be used. Go to the
 [API Reference](#api-reference) for more info.
@@ -98,6 +99,7 @@ fikkie -d
 
 ### CLI flags
 
+* **fikkie -i/--init**: Set up the ~/.fikkie directory.
 * **fikkie -d/--daemonize**: Start a fikkie daemon.
 * **fikkie -h/--help**: Show the help/usage text.
 

--- a/fikkie/config.py
+++ b/fikkie/config.py
@@ -10,64 +10,6 @@ CONFIG_FILE = os.getenv("FIKKIE_CONFIG", os.path.join(BASE_DIR, "config.yaml"))
 BROKER_DIR = os.getenv("FIKKIE_BROKER_DIR", os.path.join(BASE_DIR, "broker"))
 DB_FILENAME = os.getenv("FIKKIE_DB_FILENAME", os.path.join(BASE_DIR, "db.json"))
 
-CONFIG_TEMPLATE = """---
-## SSH config
-# Fikkie needs to know which user to use to login into the servers. This will
-# default to "fikkie".
-#
-# Example:
-#
-# ssh:
-#   username: fikkie
-
-## Servers
-# This is where you specify the commands fikkie needs to execute over SSH to
-# test them.
-#
-# Example:
-#
-# servers:
-#   primary.foo.com:
-#     - description: 'MariaDB'
-#       command: 'sudo systemctl status mariadb | grep "Active: active" -c'
-#       expected: '1'
-#     - description: 'HTTP code foo.com'
-#       command: 'curl -s -o /dev/null -w "%{http_code}" foo.com'
-#       expected: '200'
-
-## Notifiers
-# If you want fikkie to notify state changes/problems, you'll need to specify
-# the notifiers here.
-#
-# Example:
-#
-# notifiers:
-#   - type: telegram
-#     token: '1234:abcd'
-#     chat_id: 1234
-"""
-
-needed_dirs = [
-    BASE_DIR,
-    BROKER_DIR,
-    os.path.join(BROKER_DIR, "out"),
-    os.path.join(BROKER_DIR, "processed"),
-]
-for directory in needed_dirs:
-    if not os.path.isdir(directory):
-        os.mkdir(directory)
-        logging.info(f"Created directory: {directory}")
-
-
-def create_config_template(filename) -> None:
-    """Create a config template at the given location."""
-    try:
-        with open(filename, "x") as f:
-            f.write(CONFIG_TEMPLATE)
-    except Exception as e:
-        logging.error(f"Could not write config template at {filename}: {e}")
-        exit(1)
-
 
 def load_config(filename: str) -> dict:
     """Parse the config from a given file."""
@@ -75,9 +17,8 @@ def load_config(filename: str) -> dict:
         with open(filename, "r") as f:
             return yaml.safe_load(f)
     except FileNotFoundError as e:
-        create_config_template(filename)
-        logging.warning(f"Created a config template at {filename}.")
-        exit(0)
+        logging.warning("Please run `fikkie --init`.")
+        exit(1)
     except yaml.YAMLError as e:
         logging.error(f"Could not parse config: {e}")
         exit(1)

--- a/scripts/fikkie
+++ b/scripts/fikkie
@@ -2,11 +2,13 @@
 
 # This wrapper will daemonize the celery worker if the "-d" parameter is set.
 
-USAGE="fikkie [-d|--daemonize] [-h|--help]
+USAGE="fikkie [-i|--init] [-d|--daemonize] [-h|--help]
 
   Usage:
       fikkie
           Run fikkie.
+      fikkie -i
+          Initialize fikkie.
       fikkie -d
           Start a fikkie daemon.
       fikkie -h
@@ -14,9 +16,11 @@ USAGE="fikkie [-d|--daemonize] [-h|--help]
 
 Check out the docs or README at github.com/nootr/fikkie for more info."
 
+INIT=0
 DAEMONIZE=0
 
 case "$1" in
+  -i|--init)      INIT=1;;
   -d|--daemonize) DAEMONIZE=1;;
   -h|--help)      echo "$USAGE"; exit 0;;
 esac
@@ -25,6 +29,46 @@ if [ "$DAEMONIZE" -eq "1" ]; then
   # Double fork to daemonize
   (celery -A fikkie.main worker -B 1>/dev/null 2>/dev/null &) &
   echo "Fikkie daemon is running"
+elif [ "$INIT" -eq "1" ]; then
+  mkdir -p ~/.fikkie/broker/{out,processed}
+  cat > ~/.fikkie/config.yaml << EOF
+---
+## SSH config
+# Fikkie needs to know which user to use to login into the servers. This will
+# default to "fikkie".
+#
+# Example:
+#
+# ssh:
+#   username: fikkie
+
+## Servers
+# This is where you specify the commands fikkie needs to execute over SSH to
+# test them.
+#
+# Example:
+#
+# servers:
+#   primary.foo.com:
+#     - description: 'MariaDB'
+#       command: 'sudo systemctl status mariadb | grep "Active: active" -c'
+#       expected: '1'
+#     - description: 'HTTP code foo.com'
+#       command: 'curl -s -o /dev/null -w "%{http_code}" foo.com'
+#       expected: '200'
+
+## Notifiers
+# If you want fikkie to notify state changes/problems, you'll need to specify
+# the notifiers here.
+#
+# Example:
+#
+# notifiers:
+#   - type: telegram
+#     token: '1234:abcd'
+#     chat_id: 1234
+EOF
+  echo "Initialized fikkie, please check out ~/.fikkie/config.yaml"
 else
   celery -A fikkie.main worker -B
 fi


### PR DESCRIPTION
Currently, fikkie creates a working directory ("initializes") when it's
started up and can't find a config file. This is ugly for more than one
reason, so this commit moves that logic under a new flag: `--init`.