### PR TITLE
Fix bug with empty config file

### DIFF
--- a/fikkie/config.py
+++ b/fikkie/config.py
@@ -15,7 +15,7 @@ def load_config(filename: str) -> dict:
     """Parse the config from a given file."""
     try:
         with open(filename, "r") as f:
-            return yaml.safe_load(f)
+            return yaml.safe_load(f) or {}
     except FileNotFoundError as e:
         logging.warning("Please run `fikkie --init`.")
         exit(1)


### PR DESCRIPTION
Whenever `yaml.safe_load()` is used on an empty yaml-file, it returns
None. However, this causes issues as the watchdog code assumes the
returned value is a dict. This is fixed with a simple `or`.