### PR TITLE
Add e-mail notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Why use fikkie?
 
 * Fikkie is *easy* to set up
 * Fikkie is *lightweight*
-* Fikkie is *flexible* enough to be used for any service
+* Fikkie is *flexible* and could be used to monitor any service
+* Fikkie notifies you using your *favorite messaging service* (i.e. e-mail or Telegram)
 
 Simply specify which commands should be run on which servers and what output is
 expected, and fikkie will let you know when something's wrong.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 
 ## Before v0.2
 - [x] Make notifier dependencies optional (update docs)
-- [ ] Add e-mail notifier
+- [x] Add e-mail notifier
 
 ## Before v1.0
 - [ ] Write contribution guide

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] Upload to PyPi
 
 ## Before v0.2
-- [ ] Make notifier dependencies optional (update docs)
+- [x] Make notifier dependencies optional (update docs)
 - [ ] Add e-mail notifier
 
 ## Before v1.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,6 @@ SSH.
 Simply specify which commands should be run on which servers and what output is
 expected, and fikkie will let you know when something's wrong.
 
-Notifiers are written as modules, so adding a new notifier is easy! Currently,
-fikkie only supports notifying using a Telegram bot, but more options (i.e.
-e-mail, Slack, Discord) are added before version 1.0.
-
 
 ## User's guide
 
@@ -21,6 +17,7 @@ e-mail, Slack, Discord) are added before version 1.0.
   * [(Optional) Adding user](#adding-user)
   * [Setting up fikkie](#setting-up-fikkie)
 * [Setting up a notifier](#setting-up-a-notifier)
+  * [E-mail notifier](#e-mail-notifier)
   * [Telegram notifier](#telegram-notifier)
 * [Running fikkie as a daemon](#running-fikkie-as-a-daemon)
 
@@ -71,6 +68,23 @@ monitor and which notifiers should be used. Go to the
 
 
 ## Setting up a notifier
+
+### E-mail notifier
+
+The e-mail notifier needs to login on an SMTP server. In this example, GMail's SMTP
+server is used to mail to a hotmail recipient.
+
+```yaml
+notifiers:
+  - type: email
+    recipient: 'foo@hotmail.com'
+    email: 'foo@gmail.com'
+    password: 'abcdefghijkl'
+    smtp_server: 'smtp.gmail.com'
+    smtp_port: 465  # This is the default port, you can remove this line
+```
+
+Note that for this to work with GMail, you would first need to create an App Password.
 
 ### Telegram notifier
 
@@ -155,3 +169,14 @@ notifier:
     token: '1234:abcd'
     chat_id: 1234
 ```
+
+For **notifiers.type** = `email`
+* **notifiers.recipient**: The e-mail address to which notifications are sent.
+* **notifiers.email**: The e-mail address which Fikkie uses to sent.
+* **notifiers.password**: The password needed to login to the SMTP server.
+* **notifiers.smtp_server**: The SMTP server.
+* **notifiers.smtp_port** *(default: 465)*: The port on which the SMTP server listens.
+
+For **notifiers.type** = `telegram`
+* **notifiers.token**: The Telegram bot token.
+* **notifiers.chat_id**: The chat ID that Fikkie sends its notifications to.

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,9 @@ notifiers:
     chat_id: 1234
 ```
 
+The Telegram notifier uses the `python-telegram-bot` package as a dependency,
+so make sure you install that as well.
+
 
 ## Running fikkie as a daemon
 

--- a/fikkie/notifiers/__init__.py
+++ b/fikkie/notifiers/__init__.py
@@ -1,3 +1,4 @@
+from .email import EmailNotifier
 from .telegram import TelegramNotifier
 
 
@@ -6,7 +7,7 @@ class Notifier:
     A notifier factory which chooses the notifier based on the "type" param.
     """
 
-    NOTIFIERS = [TelegramNotifier]
+    NOTIFIERS = [EmailNotifier, TelegramNotifier]
 
     def __new__(cls, type: str, *args, **kwargs):
         for notifier in cls.NOTIFIERS:

--- a/fikkie/notifiers/email.py
+++ b/fikkie/notifiers/email.py
@@ -1,0 +1,45 @@
+import logging
+import smtplib
+import ssl
+
+
+__all__ = ["EmailNotifier"]
+
+
+class EmailNotifier:
+    """
+    An e-mail notifier.
+    """
+
+    TYPE = "email"
+
+    def __init__(
+        self,
+        recipient: str,
+        email: str,
+        password: str,
+        smtp_server: str,
+        smtp_port: int = 465,
+    ):
+        self._recipient = recipient
+        self._email = email
+        self._password = password
+        self._smtp_server = smtp_server
+        self._smtp_port = smtp_port
+
+    def notify(self, text: str) -> None:
+        """Sends a message."""
+        message = f"""Subject: {text}
+
+        Fikkie wants to notify you about the following message:
+
+        {text}
+        """
+
+        context = ssl.create_default_context()
+
+        with smtplib.SMTP_SSL(
+            self._smtp_server, self._smtp_port, context=context
+        ) as server:
+            server.login(self._email, self._password)
+            server.sendmail(self._email, self._recipient, message)

--- a/fikkie/notifiers/telegram.py
+++ b/fikkie/notifiers/telegram.py
@@ -1,7 +1,7 @@
-from telegram import Bot
+import logging
 
 
-__all__ = ["Notifier", "TelegramNotifier"]
+__all__ = ["TelegramNotifier"]
 
 
 class TelegramNotifier:
@@ -12,9 +12,16 @@ class TelegramNotifier:
     TYPE = "telegram"
 
     def __init__(self, token: str, chat_id: str):
+        # Only import the telegram dependency when it's needed
+        try:
+            from telegram import Bot
+        except ModuleNotFoundError:
+            logging.error("Please install the `python-telegram-bot` package.")
+            exit(1)
+
         self._bot = Bot(token=token)
         self._chat_id = chat_id
 
     def notify(self, text: str) -> None:
-        "Sends a message." ""
+        """Sends a message."""
         self._bot.sendMessage(chat_id=self._chat_id, text=text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 celery==5.2.1
-python-telegram-bot==13.9
 PyYAML==6.0
 tinydb==4.5.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     scripts=["scripts/fikkie"],
     install_requires=[
         "celery==5.2.1",
-        "python-telegram-bot==13.9",
         "PyYAML==6.0",
         "tinydb==4.5.2",
     ],


### PR DESCRIPTION
This PR adds an e-mail notifier for users to use and updates the docs and README.

It also changes the dependency of the Telegram notifier so that it's optional. This is something we want for all notifiers to prevent unnecessary dependencies.