### PR TITLE
Use correct encoding for each notifier

### DIFF
--- a/fikkie/notifiers/email.py
+++ b/fikkie/notifiers/email.py
@@ -12,6 +12,7 @@ class EmailNotifier:
     """
 
     TYPE = "email"
+    ENCODING = "ASCII"
 
     def __init__(
         self,

--- a/fikkie/notifiers/telegram.py
+++ b/fikkie/notifiers/telegram.py
@@ -10,6 +10,7 @@ class TelegramNotifier:
     """
 
     TYPE = "telegram"
+    ENCODING = "UTF-8"
 
     def __init__(self, token: str, chat_id: str):
         # Only import the telegram dependency when it's needed

--- a/fikkie/watchdog.py
+++ b/fikkie/watchdog.py
@@ -28,10 +28,12 @@ class WatchDog:
             Notifier(**n) for n in CONFIG.get("notifiers", [])
         ]
 
-    def notify(self, msg: str) -> None:
+    def notify(self, msg: str, icon: str = "") -> None:
         """Sends a notification using all available notifiers."""
         for notifier in self._notifiers:
-            notifier.notify(msg)
+            notifier.notify(
+                f"{icon} {msg}" if notifier.ENCODING == "UTF-8" and icon else msg
+            )
 
     def tick(self) -> None:
         """Perform checks."""
@@ -40,10 +42,11 @@ class WatchDog:
 
             if stdout_changed:
                 if stdout_expected:
-                    self.notify(f"🔥 {check.host}: {check.description}")
+                    self.notify(f"{check.host}: {check.description} OK", "🟢")
                 else:
                     self.notify(
-                        f"🔴 {check.host}: {check.description}\n{stdout} (stderr: {stderr})"
+                        f"{check.host}: {check.description} NOT OK\n{stdout} (stderr: {stderr})",
+                        "🔴",
                     )
 
     def heartbeat(self) -> None:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -48,9 +48,29 @@ def test_watchdog_load_config(watchdog):
     assert len(watchdog._notifiers) == 1
 
 
-def test_watchdog_notify(watchdog, mock_notifier):
+def test_watchdog_notify_no_icon(watchdog, mock_notifier):
     message = "Lorem ipsum"
     watchdog.notify(message)
+
+    mock_notifier.notify.assert_called_with(message)
+
+
+def test_watchdog_notify_utf8(watchdog, mock_notifier):
+    mock_notifier.ENCODING = "UTF-8"
+
+    message = "Lorem ipsum"
+    icon = "!"
+    watchdog.notify(message, icon)
+
+    mock_notifier.notify.assert_called_with(f"{icon} {message}")
+
+
+def test_watchdog_notify_ascii(watchdog, mock_notifier):
+    mock_notifier.ENCODING = "ASCII"
+
+    message = "Lorem ipsum"
+    icon = "!"
+    watchdog.notify(message, icon)
 
     mock_notifier.notify.assert_called_with(message)
 


### PR DESCRIPTION
Sending an e-mail with UTF-8 will fail, most SMTP server simply do not support it yet.

This commit makes sure each notifier has its encoding specified, so that no UTF-8 texts will be sent to an ASCII notifier.