### PR TITLE
Add fikkie client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install fikkie using pip and initialize fikkie:
 
 ```bash
 pip install fikkie
-fikkie --init
+fikkie init
 ```
 
 ## Config example
@@ -67,5 +67,5 @@ notifier:
 Contributions to fikkie are more than welcome!
 
 Please visit the
-[contributing guidelines](https://github.com/nootr/fikkie/blob/main/CONTRIBUTING.md)
+[contribution guidelines](https://github.com/nootr/fikkie/blob/main/CONTRIBUTING.md)
 for more info.

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,8 @@
 
 ## Before v1.0
 - [x] Write contribution guide
+- [ ] Add output formats for `fikkie status`
+- [ ] Add CLI parameter to set Celery loglevel
 - [ ] Add notifiers
 - [ ] * Slack
 - [ ] * Discord

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Installing fikkie is easy!
 
 ```bash
 pip install fikkie
-fikkie --init
+fikkie init
 ```
 
 
@@ -66,6 +66,13 @@ When you run `fikkie --init`, a configuration template is placed in
 monitor and which notifiers should be used. Go to the
 [API Reference](#api-reference) for more info.
 
+To test the configuration, start fikkie by executing:
+
+```bash
+fikkie run
+```
+
+When everything works, you can [start a fikkie daemon](#running-fikkie-as-a-daemon).
 
 ## Setting up a notifier
 
@@ -104,11 +111,17 @@ so make sure you install that as well.
 
 ## Running fikkie as a daemon
 
-When you've configured fikkie and everything works as expected, you could run
-fikkie as a daemon with the `-d` flag:
+When you've configured fikkie and everything works as expected, start a fikkie daemon as
+follows:
 
 ```bash
-fikkie -d
+fikkie start
+```
+
+Stopping the daemon is just as easy:
+
+```bash
+fikkie stop
 ```
 
 
@@ -116,8 +129,11 @@ fikkie -d
 
 ### CLI flags
 
-* **fikkie -i/--init**: Set up the ~/.fikkie directory.
-* **fikkie -d/--daemonize**: Start a fikkie daemon.
+* **fikkie init**: Set up the ~/.fikkie directory.
+* **fikkie run**: Start fikkie.
+* **fikkie start**: Start a fikkie daemon.
+* **fikkie stop**: Stop the fikkie daemon.
+* **fikkie status**: Get status from all servers.
 * **fikkie -h/--help**: Show the help/usage text.
 
 ### Environment variables
@@ -128,6 +144,8 @@ file.
 * **FIKKIE_BROKER_DIR** *(default: "~/.fikkie/broker")*: A directory containing
 the celery broker data.
 * **FIKKIE_DB_FILENAME** *(default: "~/.fikkie/db.json")*: The database file.
+* **FIKKIE_LOG_FILE** *(default: "~/.fikkie/fikkie.log")*: The daemon log file.
+* **FIKKIE_PID_FILE** *(default: "~/.fikkie/fikkie.pid")*: The PID file.
 
 
 ### Configuration options

--- a/fikkie/check.py
+++ b/fikkie/check.py
@@ -1,5 +1,7 @@
 import subprocess
+
 from tinydb import TinyDB, Query
+from typing import Literal
 
 from .config import DB_FILENAME
 
@@ -13,6 +15,22 @@ class Check:
         self.command = command
         self.expected = expected
         self.description = description
+
+    def dump(self, short: bool = False) -> dict:
+        """Returns a dictionary containing all relevant data."""
+        data = {
+            "host": self.host,
+            "command": self.command,
+            "expected": self.expected,
+            "description": self.description,
+        }
+        if not short:
+            status, stdout, stderr = self._get_status()
+            data["status"] = status
+            data["stdout"] = stdout
+            data["stderr"] = stderr
+
+        return data
 
     def _execute_ssh_command(self) -> str:
         """Executes an SSH command and returns stdout and stderr."""
@@ -35,33 +53,77 @@ class Check:
         return _decode(result.stdout), _decode(result.stderr)
 
     @property
-    def _last_stdout(self) -> str:
+    def status(self) -> str:
+        """Returns the last result status."""
+        last_result_status, _, _ = self._get_status()
+        return last_result_status
+
+    @property
+    def stdout(self) -> str:
+        """Returns the last result stdout."""
+        _, last_result_stdout, _ = self._get_status()
+        return last_result_stdout
+
+    @property
+    def stderr(self) -> str:
+        """Returns the last result stderr."""
+        _, _, last_result_stderr = self._get_status()
+        return last_result_stderr
+
+    def _get_status(self) -> tuple[str, str, str]:
+        """Returns a tuple of (last result status, last result stdout)."""
         db = TinyDB(DB_FILENAME)
-        Stdout = Query()
+        Status = Query()
 
-        values = db.search(Stdout.id == self._db_id)
-        return values[-1]["stdout"] if values else ""
+        values = db.search(Status.id == self._db_id)
 
-    @_last_stdout.setter
-    def _last_stdout(self, value) -> None:
+        if not values:
+            raise ValueError("This check hasn't run yet")
+
+        last_result_status = values[-1]["status"]
+        last_result_stdout = values[-1]["stdout"]
+        last_result_stderr = values[-1]["stderr"]
+        return last_result_status, last_result_stdout, last_result_stderr
+
+    def _set_status(
+        self, status: Literal["OK", "NOT OK", "UNKNOWN"], stdout: str, stderr: str
+    ) -> None:
+        """Sets the last result status and stdout."""
         db = TinyDB(DB_FILENAME)
-        Stdout = Query()
+        Status = Query()
 
-        if self._last_stdout:
-            db.update({"id": self._db_id, "stdout": value}, Stdout.id == self._db_id)
-        else:
-            db.insert({"id": self._db_id, "stdout": value})
+        data = {
+            "id": self._db_id,
+            "status": status,
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+
+        try:
+            self._get_status()
+        except ValueError:
+            db.insert(data)
+            return
+
+        db.update(data, Status.id == self._db_id)
 
     @property
     def _db_id(self) -> str:
-        return hash(f"{self.host}:{self.command}")
+        return f"{self.host}:{self.command}"
 
     def run(self) -> tuple[bool, bool, str, str]:
         """Executes the command and checks the results."""
 
         stdout, stderr = self._execute_ssh_command()
 
-        stdout_changed = stdout != self._last_stdout
-        self._last_stdout = stdout
+        try:
+            last_result_stdout = self.stdout
+        except ValueError:
+            last_result_stdout = None
+
+        stdout_changed = stdout != last_result_stdout
+        status = "OK" if stdout == self.expected else "NOT OK"
+
+        self._set_status(status, stdout, stderr)
 
         return stdout_changed, stdout == self.expected, stdout, stderr

--- a/fikkie/commands.py
+++ b/fikkie/commands.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+import atexit
+import logging
+import os
+import pprint
+import signal
+import sys
+
+from fikkie.config import BASE_DIR, BROKER_DIR, CONFIG_FILE, LOG_FILE, PID_FILE
+from fikkie.main import app
+from fikkie.watchdog import WatchDog
+
+
+CONFIG_TEMPLATE = """---
+## SSH config
+# Fikkie needs to know which user to use to login into the servers. This will
+# default to "fikkie".
+#
+# Example:
+#
+# ssh:
+#   username: fikkie
+
+## Servers
+# This is where you specify the commands fikkie needs to execute over SSH to
+# test them.
+#
+# Example:
+#
+# servers:
+#   primary.foo.com:
+#     - description: 'MariaDB'
+#       command: 'sudo systemctl status mariadb | grep "Active: active" -c'
+#       expected: '1'
+#     - description: 'HTTP code foo.com'
+#       command: 'curl -s -o /dev/null -w "%{http_code}" foo.com'
+#       expected: '200'
+
+## Notifiers
+# If you want fikkie to notify state changes/problems, you'll need to specify
+# the notifiers here.
+#
+# Example:
+#
+# notifiers:
+#   - type: telegram
+#     token: '1234:abcd'
+#     chat_id: 1234
+"""
+
+
+class Commands:
+    @staticmethod
+    def init():
+        """Initialize fikkie's workspace."""
+        if os.path.isdir(BASE_DIR):
+            logging.warning("Fikkie has already been initialized!")
+            exit(1)
+
+        directories = [
+            BASE_DIR,
+            BROKER_DIR,
+            os.path.join(BROKER_DIR, "out"),
+            os.path.join(BROKER_DIR, "processed"),
+        ]
+        for directory in directories:
+            os.mkdir(directory)
+
+        with open(CONFIG_FILE, "x") as f:
+            f.write(CONFIG_TEMPLATE)
+
+    @staticmethod
+    def run():
+        """Start fikkie."""
+        app.worker_main(["worker", "-B", "-l", "info"])
+
+    @staticmethod
+    def start():
+        """
+        Start a fikkie daemon.
+
+        It creates the daemon by forking two times, ensuring we can't get a controlling
+        TTY. It also changes the directory to BASE_DIR to have a gaurenteed working
+        directory. Finally, it redirects stdout and stderr to the log file and writes
+        its PID to the PID_FILE.
+        """
+        if os.path.isfile(PID_FILE):
+            logging.warning("PID file exists, is fikkie already running?")
+            exit(1)
+
+        if os.fork():
+            logging.info("Starting a fikkie daemon.")
+            sys.exit()
+
+        os.chdir(BASE_DIR)
+
+        if os.fork():
+            sys.exit()
+
+        sys.stderr.flush()
+        sys.stdout.flush()
+        with open(LOG_FILE, "a+b", 0) as log_file:
+            os.dup2(log_file.fileno(), sys.stderr.fileno())
+            os.dup2(log_file.fileno(), sys.stdout.fileno())
+
+        def _delete_pid_file():
+            os.remove(PID_FILE)
+
+        atexit.register(_delete_pid_file)
+        with open(PID_FILE, "w+") as pid_file:
+            pid_file.write(f"{os.getpid()}")
+
+        app.worker_main(["worker", "-B", "-l", "info"])
+
+    @staticmethod
+    def stop():
+        """Stop the fikkie daemon."""
+        try:
+            with open(PID_FILE, "r") as pid_file:
+                pid = int(pid_file.read().strip())
+        except FileNotFoundError:
+            logging.error("Could not find PID file. Is fikkie running?")
+            exit(1)
+
+        os.kill(pid, signal.SIGTERM)
+        logging.info("Stopped the fikkie daemon.")
+
+    @staticmethod
+    def status(output_format="JSON-PRETTY"):
+        """Get status from all servers."""
+
+        def _dump(check):
+            try:
+                return check.dump()
+            except ValueError:
+                return check.dump(short=True)
+
+        watchdog = WatchDog()
+
+        if output_format == "JSON-PRETTY":
+            data = {
+                "Daemon running": os.path.isfile(PID_FILE),
+                "checks": [_dump(check) for check in watchdog.checks],
+            }
+            pprint.pprint(data)
+            return
+
+        logging.error(f"Unknown output format: {output_format}")
+        exit(1)

--- a/fikkie/config.py
+++ b/fikkie/config.py
@@ -9,12 +9,14 @@ BASE_DIR = os.getenv("FIKKIE_BASE_DIR", os.path.expanduser("~/.fikkie"))
 CONFIG_FILE = os.getenv("FIKKIE_CONFIG", os.path.join(BASE_DIR, "config.yaml"))
 BROKER_DIR = os.getenv("FIKKIE_BROKER_DIR", os.path.join(BASE_DIR, "broker"))
 DB_FILENAME = os.getenv("FIKKIE_DB_FILENAME", os.path.join(BASE_DIR, "db.json"))
+LOG_FILE = os.getenv("FIKKIE_LOG_FILE", os.path.join(BASE_DIR, "fikkie.log"))
+PID_FILE = os.getenv("FIKKIE_PID_FILE", os.path.join(BASE_DIR, "fikkie.pid"))
 
 
-def load_config(filename: str) -> dict:
+def load_config() -> dict:
     """Parse the config from a given file."""
     try:
-        with open(filename, "r") as f:
+        with open(CONFIG_FILE, "r") as f:
             return yaml.safe_load(f) or {}
     except FileNotFoundError as e:
         logging.warning("Please run `fikkie --init`.")
@@ -22,6 +24,3 @@ def load_config(filename: str) -> dict:
     except yaml.YAMLError as e:
         logging.error(f"Could not parse config: {e}")
         exit(1)
-
-
-CONFIG = load_config(CONFIG_FILE)

--- a/scripts/fikkie
+++ b/scripts/fikkie
@@ -1,74 +1,54 @@
-#!/usr/bin/bash
+#!/usr/bin/env python
 
-# This wrapper will daemonize the celery worker if the "-d" parameter is set.
+import argparse
+import logging
 
-USAGE="fikkie [-i|--init] [-d|--daemonize] [-h|--help]
+from fikkie.commands import Commands
 
-  Usage:
-      fikkie
-          Run fikkie.
-      fikkie -i
-          Initialize fikkie.
-      fikkie -d
-          Start a fikkie daemon.
-      fikkie -h
-          Show this text.
 
-Check out the docs or README at github.com/nootr/fikkie for more info."
+DESCRIPTION = """
+             _/_/  _/  _/        _/        _/
+          _/          _/  _/    _/  _/          _/_/
+       _/_/_/_/  _/  _/_/      _/_/      _/  _/_/_/_/
+        _/      _/  _/  _/    _/  _/    _/  _/
+       _/      _/  _/    _/  _/    _/  _/    _/_/_/
 
-INIT=0
-DAEMONIZE=0
+                     https://github.com/nootr/fikkie/
+                      https://nootr.github.io/fikkie/
 
-case "$1" in
-  -i|--init)      INIT=1;;
-  -d|--daemonize) DAEMONIZE=1;;
-  -h|--help)      echo "$USAGE"; exit 0;;
-esac
+A simple lightweight watchdog which monitors external services
+over SSH.
+"""
 
-if [ "$DAEMONIZE" -eq "1" ]; then
-  # Double fork to daemonize
-  (celery -A fikkie.main worker -B 1>/dev/null 2>/dev/null &) &
-  echo "Fikkie daemon is running"
-elif [ "$INIT" -eq "1" ]; then
-  mkdir -p ~/.fikkie/broker/{out,processed}
-  cat > ~/.fikkie/config.yaml << EOF
----
-## SSH config
-# Fikkie needs to know which user to use to login into the servers. This will
-# default to "fikkie".
-#
-# Example:
-#
-# ssh:
-#   username: fikkie
+COMMAND_HELP = """
+init  - Initialize fikkie's workspace.
+run   - Start fikkie.
+start - Start a fikkie daemon.
+stop  - Stop the fikkie daemon.
+status - Get status from all servers.
+"""
 
-## Servers
-# This is where you specify the commands fikkie needs to execute over SSH to
-# test them.
-#
-# Example:
-#
-# servers:
-#   primary.foo.com:
-#     - description: 'MariaDB'
-#       command: 'sudo systemctl status mariadb | grep "Active: active" -c'
-#       expected: '1'
-#     - description: 'HTTP code foo.com'
-#       command: 'curl -s -o /dev/null -w "%{http_code}" foo.com'
-#       expected: '200'
 
-## Notifiers
-# If you want fikkie to notify state changes/problems, you'll need to specify
-# the notifiers here.
-#
-# Example:
-#
-# notifiers:
-#   - type: telegram
-#     token: '1234:abcd'
-#     chat_id: 1234
-EOF
-  echo "Initialized fikkie, please check out ~/.fikkie/config.yaml"
-else
-  celery -A fikkie.main worker -B
-fi
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION, formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument(
+        "command",
+        help=COMMAND_HELP,
+        action="store",
+        choices=["init", "run", "start", "stop", "status"],
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-8s %(message)s", level=logging.INFO
+    )
+
+    args = parse_args()
+    kwargs = vars(args)
+    getattr(Commands, args.command)()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+import pytest
+
+from fikkie.watchdog import WatchDog
+
+
+@pytest.fixture
+def mock_config():
+    yield {
+        "servers": {
+            "foo.bar": [
+                {
+                    "description": "foo",
+                    "command": "echo foo",
+                    "expected": "foo",
+                }
+            ]
+        },
+        "notifiers": [
+            {
+                "type": "telegram",
+                "token": "1234:abcd",
+                "chat_id": 1234,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def mock_notifier(mocker):
+    yield mocker.Mock()
+
+
+@pytest.fixture
+def mock_check(mocker):
+    yield mocker.Mock()
+
+
+@pytest.fixture
+def watchdog(mocker, mock_config, mock_notifier, mock_check):
+    mocker.patch("fikkie.watchdog.CONFIG", mock_config)
+    mocker.patch("fikkie.watchdog.Notifier", return_value=mock_notifier)
+    mocker.patch("fikkie.watchdog.Check", return_value=mock_check)
+    yield WatchDog()
+
+
+@pytest.fixture
+def mock_no_config(mocker):
+    yield mocker.patch("os.path.isdir", return_value=False)
+
+
+@pytest.fixture
+def mock_os_mkdir(mocker):
+    yield mocker.patch("os.mkdir")
+
+
+@pytest.fixture
+def mock_file(mocker):
+    yield mocker.Mock()
+
+
+@pytest.fixture
+def mock_open(mocker, mock_file):
+    _mock_open = mocker.MagicMock()
+    _mock_open.__enter__.return_value = mock_file
+    yield mocker.patch("builtins.open", return_value=_mock_open)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,19 @@
+import pytest
+
+from fikkie.commands import Commands
+
+
+def test_scripts_init(mock_os_mkdir, mock_open, mock_file, mock_no_config):
+    Commands.init()
+
+    assert mock_os_mkdir.call_count == 4
+    mock_file.write.assert_called()
+
+
+def test_scripts_status(watchdog, capsys):
+    Commands.status()
+
+    output = capsys.readouterr().out
+
+    assert "'Daemon running':" in output
+    assert "'checks':" in output

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -3,48 +3,8 @@ import pytest
 from fikkie.watchdog import WatchDog
 
 
-@pytest.fixture
-def mock_config():
-    yield {
-        "servers": {
-            "foo.bar": [
-                {
-                    "description": "foo",
-                    "command": "echo foo",
-                    "expected": "foo",
-                }
-            ]
-        },
-        "notifiers": [
-            {
-                "type": "telegram",
-                "token": "1234:abcd",
-                "chat_id": 1234,
-            }
-        ],
-    }
-
-
-@pytest.fixture
-def mock_notifier(mocker):
-    yield mocker.Mock()
-
-
-@pytest.fixture
-def mock_check(mocker):
-    yield mocker.Mock()
-
-
-@pytest.fixture
-def watchdog(mocker, mock_config, mock_notifier, mock_check):
-    mocker.patch("fikkie.watchdog.CONFIG", mock_config)
-    mocker.patch("fikkie.watchdog.Notifier", return_value=mock_notifier)
-    mocker.patch("fikkie.watchdog.Check", return_value=mock_check)
-    yield WatchDog()
-
-
 def test_watchdog_load_config(watchdog):
-    assert len(watchdog._checks) == 1
+    assert len(watchdog.checks) == 1
     assert len(watchdog._notifiers) == 1
 
 


### PR DESCRIPTION
This commit removes the `fikkie` bash-script and replaces it with a more complete python script. Its main purpose is to control the daemon and read out the checks data.

Related to #5.