### PR TITLE
Run tests on each Python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,12 +29,15 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python_version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'releases/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
   workflow_dispatch:
 
 jobs:

--- a/fikkie/check.py
+++ b/fikkie/check.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from tinydb import TinyDB, Query
-from typing import Literal
+from typing import Literal, Tuple
 
 from .config import DB_FILENAME
 
@@ -70,7 +70,7 @@ class Check:
         _, _, last_result_stderr = self._get_status()
         return last_result_stderr
 
-    def _get_status(self) -> tuple[str, str, str]:
+    def _get_status(self) -> Tuple[str, str, str]:
         """Returns a tuple of (last result status, last result stdout)."""
         db = TinyDB(DB_FILENAME)
         Status = Query()
@@ -111,7 +111,7 @@ class Check:
     def _db_id(self) -> str:
         return f"{self.host}:{self.command}"
 
-    def run(self) -> tuple[bool, bool, str, str]:
+    def run(self) -> Tuple[bool, bool, str, str]:
         """Executes the command and checks the results."""
 
         stdout, stderr = self._execute_ssh_command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-celery==5.2.1
-PyYAML==6.0
-tinydb==4.5.2
+celery
+PyYAML
+tinydb
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setup(
     packages=["fikkie", "fikkie.notifiers"],
     scripts=["scripts/fikkie"],
     install_requires=[
-        "celery==5.2.1",
-        "PyYAML==6.0",
-        "tinydb==4.5.2",
+        "celery",
+        "PyYAML",
+        "tinydb",
+        "typing_extensions",
     ],
 )


### PR DESCRIPTION
In order to keep track of the supported Python versions, we need to execute the tests on each of them.