### PR TITLE
Add argument to select output format

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@
 - [x] Write contribution guide
 - [ ] Document supported Python versions
 - [ ] Add mypy to CI/CD pipeline
-- [ ] Add output formats for `fikkie status`
+- [x] Add output formats for `fikkie status`
 - [ ] Add CLI parameter to set Celery loglevel
 - [ ] Add notifiers
 - [ ] * Slack

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,7 +133,7 @@ fikkie stop
 * **fikkie run**: Start fikkie.
 * **fikkie start**: Start a fikkie daemon.
 * **fikkie stop**: Stop the fikkie daemon.
-* **fikkie status**: Get status from all servers.
+* **fikkie status [--format {YAML,JSON,JSON-PRETTY}]**: Get status from all servers.
 * **fikkie -h/--help**: Show the help/usage text.
 
 ### Environment variables

--- a/fikkie/commands.py
+++ b/fikkie/commands.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
 import atexit
+import json
 import logging
 import os
 import pprint
 import signal
 import sys
+import yaml
+
+from typing import Literal
 
 from fikkie.config import BASE_DIR, BROKER_DIR, CONFIG_FILE, LOG_FILE, PID_FILE
 from fikkie.main import app
@@ -51,8 +55,10 @@ CONFIG_TEMPLATE = """---
 
 
 class Commands:
+    FORMAT_OPTIONS = ["YAML", "JSON", "JSON-PRETTY"]
+
     @staticmethod
-    def init():
+    def init(*args, **kwargs):
         """Initialize fikkie's workspace."""
         if os.path.isdir(BASE_DIR):
             logging.warning("Fikkie has already been initialized!")
@@ -71,12 +77,12 @@ class Commands:
             f.write(CONFIG_TEMPLATE)
 
     @staticmethod
-    def run():
+    def run(*args, **kwargs):
         """Start fikkie."""
         app.worker_main(["worker", "-B", "-l", "info"])
 
     @staticmethod
-    def start():
+    def start(*args, **kwargs):
         """
         Start a fikkie daemon.
 
@@ -114,7 +120,7 @@ class Commands:
         app.worker_main(["worker", "-B", "-l", "info"])
 
     @staticmethod
-    def stop():
+    def stop(*args, **kwargs):
         """Stop the fikkie daemon."""
         try:
             with open(PID_FILE, "r") as pid_file:
@@ -123,11 +129,15 @@ class Commands:
             logging.error("Could not find PID file. Is fikkie running?")
             exit(1)
 
-        os.kill(pid, signal.SIGTERM)
-        logging.info("Stopped the fikkie daemon.")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logging.info("Stopped the fikkie daemon.")
+        except ProcessLookupError:
+            os.remove(PID_FILE)
+            logging.warning("The fikkie daemon had already stopped.")
 
     @staticmethod
-    def status(output_format="JSON-PRETTY"):
+    def status(output_format: Literal["YAML", "JSON", "JSON-PRETTY"], *args, **kwargs):
         """Get status from all servers."""
 
         def _dump(check):
@@ -137,14 +147,17 @@ class Commands:
                 return check.dump(short=True)
 
         watchdog = WatchDog()
+        data = {
+            "Daemon running": os.path.isfile(PID_FILE),
+            "checks": [_dump(check) for check in watchdog.checks],
+        }
 
-        if output_format == "JSON-PRETTY":
-            data = {
-                "Daemon running": os.path.isfile(PID_FILE),
-                "checks": [_dump(check) for check in watchdog.checks],
-            }
+        if output_format.upper() == "YAML":
+            print(yaml.safe_dump(data))
+        elif output_format.upper() == "JSON":
+            print(json.dumps(data))
+        elif output_format.upper() == "JSON-PRETTY":
             pprint.pprint(data)
-            return
-
-        logging.error(f"Unknown output format: {output_format}")
-        exit(1)
+        else:
+            logging.error(f"Unknown output format: {output_format}")
+            exit(1)

--- a/scripts/fikkie
+++ b/scripts/fikkie
@@ -41,6 +41,15 @@ def parse_args():
         choices=["init", "run", "start", "stop", "status"],
     )
 
+    parser.add_argument(
+        "--format",
+        help="The output format of `fikkie status` (default: YAML).",
+        action="store",
+        choices=Commands.FORMAT_OPTIONS,
+        default="YAML",
+        type=str.upper,
+    )
+
     return parser.parse_args()
 
 
@@ -51,4 +60,4 @@ if __name__ == "__main__":
 
     args = parse_args()
     kwargs = vars(args)
-    getattr(Commands, args.command)()
+    getattr(Commands, args.command)(output_format=args.format)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,9 +11,9 @@ def test_scripts_init(mock_os_mkdir, mock_open, mock_file, mock_no_config):
 
 
 def test_scripts_status(watchdog, capsys):
-    Commands.status()
+    Commands.status(output_format="JSON-PRETTY")
 
     output = capsys.readouterr().out
 
-    assert "'Daemon running':" in output
+    assert "{'Daemon running':" in output
     assert "'checks':" in output


### PR DESCRIPTION
This commit adds output formats "JSON" and "YAML" to the existing "JSON-PRETTY" and sets "YAML" as the default as that is the most human-readable option.