### PR TITLE
Make heartbeat schedule configurable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,6 +84,40 @@
 
 ### Configuration options
 
+| heartbeat.enable *(default: True)* |
+|:-----------------------------------|
+| Heartbeat is enabled if True.      |
+
+| heartbeat.timezone *(default: "UTC")* |
+|:--------------------------------------|
+| The schedule timezone.                |
+
+| heartbeat.schedule.minute *(default: 0)*    |
+|:--------------------------------------------|
+| Minute on which the heartbeat is triggered. |
+
+| heartbeat.schedule.hour *(default: 12)*   |
+|:------------------------------------------|
+| Hour on which the heartbeat is triggered. |
+
+| heartbeat.schedule.day_of_week *(default: '*')*                                    |
+|:-----------------------------------------------------------------------------------|
+| Day(s) of the week (0 = Sunday, 6 = Saturday) on which the heartbeat is triggered. |
+
+| heartbeat.schedule.day_of_month *(default: '*')*                |
+|:----------------------------------------------------------------|
+| Day(s) of the month (0-31) on which the heartbeat is triggered. |
+
+Example:
+
+```yaml
+heartbeat:
+  timezone: 'Europe/Amsterdam'
+  schedule:
+    hour: 13
+    minute: 37
+```
+
 | ssh.username *(default: "fikkie")* |
 |:-----------------------------------|
 | The SSH login username.            |

--- a/fikkie/commands.py
+++ b/fikkie/commands.py
@@ -19,9 +19,28 @@ except ImportError:  # pragma: no cover - no need to test Python's stdlib
 
 
 CONFIG_TEMPLATE = """---
+## Heartbeat schedule
+# Fikkie will notify you periodically about it still being alive. This is where you
+# could change the schedule or disable it altogether.
+#
+# Note that the `minute`, `hour`, `day_of_week` and `day_of_month` values are either (a
+# list of) integers or Celery Crontab patterns. Please read the Celery documentation for
+# more info.
+#
+# Example:
+#
+# heartbeat:
+#   enable: True
+#   timezone: 'UTC'
+#   schedule:
+#     minute: 0
+#     hour: 12
+#     day_of_week: '*'  # Sunday = 0 and Saturday = 6
+#     day_of_month: '*'
+
 ## SSH config
-# Fikkie needs to know which user to use to login into the servers. This will
-# default to "fikkie".
+# Fikkie needs to know which user to use to login into the servers. This will default to
+# "fikkie".
 #
 # Example:
 #
@@ -29,8 +48,7 @@ CONFIG_TEMPLATE = """---
 #   username: fikkie
 
 ## Servers
-# This is where you specify the commands fikkie needs to execute over SSH to
-# test them.
+# This is where you specify the commands fikkie needs to execute over SSH to test them.
 #
 # Example:
 #
@@ -44,8 +62,8 @@ CONFIG_TEMPLATE = """---
 #       expected: '200'
 
 ## Notifiers
-# If you want fikkie to notify state changes/problems, you'll need to specify
-# the notifiers here.
+# If you want fikkie to notify state changes/problems, you'll need to specify the
+# notifiers here.
 #
 # Example:
 #

--- a/fikkie/main.py
+++ b/fikkie/main.py
@@ -1,9 +1,8 @@
 from celery import Celery
-from celery.schedules import crontab
 
 import os
 
-from .config import BROKER_DIR
+from .config import BROKER_DIR, get_schedule
 from .watchdog import WatchDog
 
 
@@ -22,13 +21,7 @@ app.conf.update(
         "accept_content": ["json"],
     }
 )
-app.conf.beat_schedule = {
-    "tick": {"task": "fikkie.main.tick", "schedule": 60},
-    "heartbeat": {
-        "task": "fikkie.main.heartbeat",
-        "schedule": crontab(hour=12, minute=0),  # NOTE: This is UTC 12:00
-    },
-}
+app.conf.beat_schedule, app.conf.timezone = get_schedule()
 
 
 @app.task

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -31,8 +31,9 @@ def mock_hikari_import(mocker):
 
 
 @pytest.fixture
-def mock_config():
+def mock_config_data():
     yield {
+        "heartbeat": {"schedule": {"hour": 13, "minute": 37}},
         "servers": {
             "foo.bar": [
                 {
@@ -50,6 +51,13 @@ def mock_config():
             }
         ],
     }
+
+
+@pytest.fixture
+def mock_config_no_heartbeat_data(mock_config_data):
+    config = mock_config_data
+    config["heartbeat"] = {"enable": False}
+    yield config
 
 
 @pytest.fixture
@@ -120,7 +128,6 @@ def check(mocker, mock_check_status, mock_ssh_output):
 
 @pytest.fixture
 def watchdog(mocker, mock_config, mock_notifier, check):
-    mocker.patch("fikkie.watchdog.load_config", return_value=mock_config)
     mocker.patch("fikkie.watchdog.Notifier", return_value=mock_notifier)
     mocker.patch("fikkie.watchdog.Check", return_value=check)
     yield WatchDog()
@@ -184,3 +191,16 @@ def awaitable_magicmock(mocker):
         pass
 
     mocker.MagicMock.__await__ = lambda x: _async_method().__await__()
+
+
+@pytest.fixture
+def mock_config(mocker, mock_config_data):
+    mocker.patch("fikkie.config.load_config", return_value=mock_config_data)
+    mocker.patch("fikkie.watchdog.load_config", return_value=mock_config_data)
+
+
+@pytest.fixture
+def mock_config_no_heartbeat(mocker, mock_config_no_heartbeat_data):
+    mocker.patch(
+        "fikkie.config.load_config", return_value=mock_config_no_heartbeat_data
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+from fikkie.config import get_schedule
+
+
+def test_schedule(mock_config):
+    schedule, timezone = get_schedule()
+
+    assert schedule["tick"]["schedule"] == 60
+    assert schedule["heartbeat"]["schedule"].minute == {37}
+    assert schedule["heartbeat"]["schedule"].hour == {13}
+    assert schedule["heartbeat"]["schedule"].day_of_week == set(range(7))
+    assert schedule["heartbeat"]["schedule"].day_of_month == set(range(1, 32))
+    assert timezone == "UTC"
+
+
+def test_default_schedule_no_config(mock_no_config):
+    schedule, timezone = get_schedule()
+
+    assert schedule["tick"]["schedule"] == 60
+    assert schedule["heartbeat"]["schedule"].minute == {0}
+    assert schedule["heartbeat"]["schedule"].hour == {12}
+    assert schedule["heartbeat"]["schedule"].day_of_week == set(range(7))
+    assert schedule["heartbeat"]["schedule"].day_of_month == set(range(1, 32))
+    assert timezone == "UTC"
+
+
+def test_disable_heartbeat(mock_config_no_heartbeat):
+    schedule, _ = get_schedule()
+
+    assert "tick" in schedule
+    assert "heartbeat" not in schedule


### PR DESCRIPTION
Obviously 12:00 UTC is very inconvenient for a lot of people, while the heartbeat might even be annoying for some. This is why this PR adds the option to disable or adjust the heartbeat schedule.