### PR TITLE
Build Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+docs/
+tests/
+venv/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,27 +7,72 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  publish-pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r build-requirements.txt
+
     - name: Build
       run: |
         make build
+
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-docker:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            nootr/fikkie
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-alpine
+
+WORKDIR /root
+
+COPY . .
+RUN pip3 install .
+
+# Install optional dependencies for notifiers
+RUN pip3 install slack_sdk hikari python-telegram-bot
+
+RUN fikkie init
+
+CMD [ "fikkie", "run" ]

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ functional:
 
 build:
 	python -m build
+
+image:
+	docker build --tag fikkie:latest .

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI license](https://img.shields.io/pypi/l/fikkie.svg)](https://github.com/nootr/fikkie/blob/main/LICENSE.md)
 [![PyPi version](https://badgen.net/pypi/v/fikkie/)](https://pypi.org/project/fikkie)
 [![Downloads](https://pepy.tech/badge/fikkie)](https://pepy.tech/project/fikkie)
+[![Docker pulls](https://img.shields.io/docker/pulls/nootr/fikkie)](https://hub.docker.com/repository/docker/nootr/fikkie)
 [![Linux](https://svgshare.com/i/Zhy.svg)](https://svgshare.com/i/Zhy.svg)
 [![macOS](https://svgshare.com/i/ZjP.svg)](https://svgshare.com/i/ZjP.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -34,8 +35,9 @@ Why use fikkie?
 * Fikkie notifies you using your *favorite messaging service* (e.g. e-mail, Discord or
 Telegram)
 
-Simply specify which commands should be run on which servers and what output is
-expected, and fikkie will let you know when something's wrong.
+You just need one single YAML file to configure fikkie, so simply specify which commands
+should be run on which servers and what output is expected, and fikkie will let you know
+when something's wrong.
 
 
 ## Installation
@@ -45,6 +47,14 @@ Install fikkie using pip and initialize fikkie:
 ```bash
 pip install fikkie
 fikkie init
+```
+
+Or use Docker!
+
+```bash
+docker run \
+  --mount type=bind,source=${PWD}/config.yaml,target=/root/.fikkie/config.yaml \
+  nootr/fikkie:latest
 ```
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+---
+heartbeat:
+  schedule:
+    minute: '*'
+    hour: '*'
+  timezone: 'Europe/Amsterdam'

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -8,3 +8,18 @@ fikkie init
 ```
 
 Fikkie works with Python 3.7 or higher.
+
+
+## Running fikkie in a Docker container
+
+There is a Docker image for fikkie available, so just run it while binding your
+configuration file and you're ready.
+
+```bash
+docker run \
+  --mount type=bind,source=${PWD}/config.yaml,target=/root/.fikkie/config.yaml \
+  nootr/fikkie:latest
+```
+
+This snippet assumes `config.yaml` lives in your current directory. If it does not,
+please change the value of `source=`.


### PR DESCRIPTION
It would be very convenient to build a fikkie Docker image in the CI/CD pipeline. For example, it allows Windows users to easily use it without needing to add Windows environments to the tests.

TODO:
- [x] Create Dockerfile
- [x] Build and push image in GitHub Actions
- [x] Update documentation